### PR TITLE
Maintainers should be an array

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "talkin",
   "version": "1.3.2",
   "author": "LinkedIn",
-  "maintainers": "Kevin Mikles <kmikles@linkedin.com>",
+  "maintainers": ["Kevin Mikles <kmikles@linkedin.com>"],
   "licenses": [
     {
       "type": "Apache License, Version 2.0",


### PR DESCRIPTION
See https://github.com/npm/npm/issues/11056 for examples of `npm` issues that can arise when `maintainers` is not an array.